### PR TITLE
add support for es6 or coffee script syntax

### DIFF
--- a/plugin/require-navigator.vim
+++ b/plugin/require-navigator.vim
@@ -58,10 +58,13 @@ endfunction
 
 function! FindFile()
 	let cn = col('.')
-	normal yi(
+	if getline('.') =~ "'"
+		normal "ryi'
+	else
+		normal "ryi"
+	endif
 	exe 'normal' cn.'|'
 	let relativepath = @
-	let relativepath = relativepath[1:-2]
 	if relativepath =~ '^\.'
 		let dir = expand('%:p:h')
 		let filename = dir.'/'.relativepath


### PR DESCRIPTION
This PR adds support for this syntax

``` es6
import utils from './utils';
```

or 

``` coffee
utils = require "utils";
```

Additionally yank into non-default register ("r) so your most recent copy is not reset by the plugin

I'm not experienced in vimscript so - sorry if the code is stupid, maybe there are better ways?
